### PR TITLE
Depend only on Texture/Core

### DIFF
--- a/ASDKFluentExtensions.podspec
+++ b/ASDKFluentExtensions.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |spec|
 
   spec.public_header_files  = 'Source/*.h'
   spec.source_files = 'Source/*.{h,m}'
-  spec.dependency 'Texture', '~> 2.6'
+  spec.dependency 'Texture/Core', '~> 2.6'
 
 end

--- a/Podfile
+++ b/Podfile
@@ -8,5 +8,5 @@ workspace 'ASDKFluentExtensions'
 project 'ASDKFluentExtensions.xcodeproj'
 
 target 'ASDKFluentExtensions' do
-	pod 'Texture', '~> 2.6'
+	pod 'Texture/Core', '~> 2.6'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,36 +1,12 @@
 PODS:
-  - PINCache (3.0.1-beta.5):
-    - PINCache/Arc-exception-safe (= 3.0.1-beta.5)
-    - PINCache/Core (= 3.0.1-beta.5)
-  - PINCache/Arc-exception-safe (3.0.1-beta.5):
-    - PINCache/Core
-  - PINCache/Core (3.0.1-beta.5):
-    - PINOperation (= 1.0.3)
-  - PINOperation (1.0.3)
-  - PINRemoteImage/Core (3.0.0-beta.11):
-    - PINOperation
-  - PINRemoteImage/iOS (3.0.0-beta.11):
-    - PINRemoteImage/Core
-  - PINRemoteImage/PINCache (3.0.0-beta.11):
-    - PINCache (= 3.0.1-beta.5)
-    - PINRemoteImage/Core
-  - Texture (2.4):
-    - Texture/PINRemoteImage (= 2.4)
-  - Texture/Core (2.4)
-  - Texture/PINRemoteImage (2.4):
-    - PINRemoteImage/iOS (= 3.0.0-beta.11)
-    - PINRemoteImage/PINCache
-    - Texture/Core
+  - Texture/Core (2.6)
 
 DEPENDENCIES:
-  - Texture (~> 2.4)
+  - Texture/Core (~> 2.6)
 
 SPEC CHECKSUMS:
-  PINCache: 98e7b1ef782824ad231ade51987c218b758c30d8
-  PINOperation: ac23db44796d4a564ecf9b5ea7163510f579b71d
-  PINRemoteImage: d71988f11914a050d6d4cf51efc4ad1de8c0a9d8
-  Texture: a5526314780eab35f642d956627f09316b9514e8
+  Texture: 7249074582daf75e524e59df5428b66b8e8db0e4
 
-PODFILE CHECKSUM: 61819956f99236890c1d84a3097dd344cc04bb53
+PODFILE CHECKSUM: a54489ce34099d8e645c1d21b60d59c029c7b73e
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
**ASDKFluentExtensions** depends on Texture which come with a bundle of other frameworks : _PinRemoteImage, Yoga, IGListKit_.
This framework doesn't extend those, but only Texture core framework.

Then we can only depend on Texture/Core. This will allow use of Texture/Core with **ASDKFluentExtensions**, without forcing to depend on unneeded _PinRemoteImage, Yoga, IGListKit_.

This will affect only users who use `pod 'Texture/Core', '~> x.x'` in their Podfile instead of `pod 'Texture', '~> x.x'`


_PS: Great framework, I use it since I started using Texture ! Many thanks_